### PR TITLE
Spelling improvements and function ordering

### DIFF
--- a/Scheduler.au3
+++ b/Scheduler.au3
@@ -107,24 +107,6 @@ Func _Scheduler_Run($aScheduleOrTimeSheet, $udfCallback, $udfInfoCallback = Null
 	WEnd
 EndFunc
 
-; #INTERNAL_USE_ONLY# ===========================================================================================================
-; Name ..........: __Scheduler_Run_Sleep
-; Description ...: Sleep for the given duration or until interrupted with _Scheduler_Stop
-; Syntax ........: __Scheduler_Run_Sleep($iDuration)
-; Parameters ....: $iDuration           - Sleep duration in milli-seconds.
-; Return values .: @error is set to 1 if interrupted
-; Author ........: TheDcoder
-; Related .......: _Scheduler_Stop
-; Example .......: __Scheduler_Run_Sleep(420)
-; ===============================================================================================================================
-Func __Scheduler_Run_Sleep($iDuration)
-	Local $hTimer = TimerInit()
-	Do
-		Sleep($g_bScheduler_SleepInterval)
-	Until $g__bScheduler_InterruptSleep Or TimerDiff($hTimer) > $iDuration
-	Return SetError($g__bScheduler_InterruptSleep ? 1 : 0)
-EndFunc
-
 ; #FUNCTION# ====================================================================================================================
 ; Name ..........: _Scheduler_Stop
 ; Description ...: Interrupt the running schedule
@@ -317,4 +299,22 @@ Func _Scheduler_TimeToString($iTime, $bIncludeMs = False)
 	EndIf
 
 	Return $sTime
+EndFunc
+
+; #INTERNAL_USE_ONLY# ===========================================================================================================
+; Name ..........: __Scheduler_Run_Sleep
+; Description ...: Sleep for the given duration or until interrupted with _Scheduler_Stop
+; Syntax ........: __Scheduler_Run_Sleep($iDuration)
+; Parameters ....: $iDuration           - Sleep duration in milliseconds.
+; Return values .: @error is set to 1 if interrupted
+; Author ........: TheDcoder
+; Related .......: _Scheduler_Stop
+; Example .......: __Scheduler_Run_Sleep(420)
+; ===============================================================================================================================
+Func __Scheduler_Run_Sleep($iDuration)
+	Local $hTimer = TimerInit()
+	Do
+		Sleep($g_bScheduler_SleepInterval)
+	Until $g__bScheduler_InterruptSleep Or TimerDiff($hTimer) > $iDuration
+	Return SetError($g__bScheduler_InterruptSleep ? 1 : 0)
 EndFunc

--- a/Scheduler.au3
+++ b/Scheduler.au3
@@ -54,12 +54,12 @@ Global $g__bScheduler_InterruptSleep = False
 ;                  $bSkipLateTasks      - [optional] Skip tasks which are late? Default is False.
 ; Return values .: None, does not return until _Scheduler_Stop is called.
 ; Author ........: TheDcoder
-; Remarks .......: This function is an event-loop, See _Scheduler_MakeTimesheet for the format of a schedule.
+; Remarks .......: This function is an event-loop, see _Scheduler_MakeTimesheet for the format of a schedule.
 ;                  The $udfInfoCallback function will be called before each task with two pieces of information as arguments:
 ;                  1. $vTask - The task which is scheduled to run next
-;                  2. $iWait - The remaining time until the task will run (in milli-seconds)
+;                  2. $iWait - The remaining time until the task will run (in milliseconds)
 ;                  Note: After all the tasks have been ran, $udfInfoCallback will be call one last time for this day and
-;                        $vTask will be set to Null and $iWait will contain the time until mid-night, after which the schedule will
+;                        $vTask will be set to Null and $iWait will contain the time until midnight, after which the schedule will
 ;                        resume as usual.
 ; Related .......: _Scheduler_Stop
 ; ===============================================================================================================================
@@ -161,7 +161,7 @@ EndFunc
 ;
 ;                  $aSchedule[2][$geScheduler_EnumTask] = "baz"
 ;                  Local $aBazSubSchedule[3] ; This task has a mini sub-schedule, so it can run multiple times in a day!
-;                  $aBazSubSchedule[0] = '0' ; Mid-night (start of the day)
+;                  $aBazSubSchedule[0] = '0' ; Midnight (start of the day)
 ;                  $aBazSubSchedule[1] = '9:30' ; 9:30 AM
 ;                  $aBazSubSchedule[2] = '17:18:19' ; 5:18 PM + 19 seconds
 ;                  $aSchedule[2][$geScheduler_EnumTime] = $aBazSubSchedule ; Run 3 times a day at given times
@@ -234,14 +234,14 @@ EndFunc
 ; Description ...: Convert a timestamp to an integer for use in timesheets
 ; Syntax ........: _Scheduler_StampToTime($sStamp)
 ; Parameters ....: $sStamp              - The timestamp, see remarks.
-; Return values .: An integer which represents the timestamp as the duration from the start of the day (mid-night) in milli-seconds
+; Return values .: An integer which represents the timestamp as the duration from the start of the day (midnight) in milliseconds
 ; Author ........: TheDcoder
 ; Remarks .......: The format of the timestamp is simple, it is a string with numbers delimited with `:`.
 ;                  A timestamp can have 4 components (all are optional):
 ;                  1. Hours
 ;                  2. Minutes
 ;                  3. Seconds
-;                  4. Milli-seconds
+;                  4. Milliseconds
 ;
 ;                  Padding of numbers with 0 is optionally allowed since the `Number` function is used for conversion to integer
 ; Related .......: _Scheduler_MakeTimesheet
@@ -260,7 +260,7 @@ Func _Scheduler_StampToTime($sStamp)
 			; Second
 			$iMultiplier = 1000
 		ElseIf $i = 4 Then
-			; Milli-Second
+			; Millisecond
 			$iMultiplier = 1
 		Else
 			; Invalid
@@ -276,7 +276,7 @@ EndFunc
 ; Description ...: Get the current time of day
 ; Syntax ........: _Scheduler_GetCurTime()
 ; Parameters ....: None
-; Return values .: The number of milli-seconds elasped since mid-night
+; Return values .: The number of milliseconds elasped since midnight
 ; Author ........: TheDcoder
 ; Remarks .......: This is mostly used internally but you can use this to make your own dynamic timesheets manually
 ; Example .......: $aSheet[0][$geScheduler_EnumTime] = _Scheduler_GetCurTime() + _Scheduler_StampToTime('0:0:10') ; 10 seconds from now
@@ -295,7 +295,7 @@ EndFunc
 ; Description ...: Convert time to an user-friendly string for display
 ; Syntax ........: _Scheduler_TimeToString($iTime[, $bIncludeMs = False])
 ; Parameters ....: $iTime               - The time as returned by _Scheduler_StampToTime.
-;                  $bIncludeMs          - [optional] Include milli-seconds? Default is False.
+;                  $bIncludeMs          - [optional] Include milliseconds? Default is False.
 ; Return values .: An user-friendly string representation
 ; Author ........: TheDcoder
 ; Related .......: _Scheduler_StampToTime


### PR DESCRIPTION
Hi @TheDcoder ,

these are the changes in this PR:

(1) I simple changed three words.

- ", See" to ", see"
- "milli-seconds" to "milliseconds"
- "mid-night" to "midnight"

The first one is a typo I guess and the other two are not compound words.

(2) I moved the "INTERNAL_USE_ONLY" function `__Scheduler_Run_Sleep` to the bottom of the UDF.
Because like in other programming languages a function (method) ordering is commonly used.

I hope you are fine with this minor changes 🤞 .
The other two PRs are more code practical and more exciting, I promise 😅 .

Best regards
Sven